### PR TITLE
Using filter sortByOrder instead of modifying order of projects

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -37,10 +37,10 @@ module.exports = function(eleventyConfig) {
     }, {});
   });
 
-  // Sort projects by date
-  eleventyConfig.addCollection('project', collection => {
-    return collection.getFilteredByGlob("projects/**/*.md")
-        .sort((a, b) => b.data.order - a.data.order);
+  // Sort by order
+  eleventyConfig.addFilter("sortByOrder", values => {
+    let vals = [...values];
+    return vals.sort((a, b) => a.data.order - b.data.order);
   });
 
   // Date formatting (human readable)

--- a/_includes/components/projectlist.njk
+++ b/_includes/components/projectlist.njk
@@ -1,6 +1,6 @@
 <section>
   <div class="project-grid">
-    {% for post in projectlist | reverse %}
+    {% for post in projectlist %}
       <div class="project-card" {% if post.url == url %} data-current="current item"{% endif %}>
         <h4>
           <a class="project-card__title" href="{{ post.url | url }}">

--- a/_includes/layouts/projects.njk
+++ b/_includes/layouts/projects.njk
@@ -10,6 +10,6 @@ section: projects
   <hr>
   {{ layoutContent | safe }}
 
-  {% set projectlist = collections.project %}
+  {% set projectlist = collections.project | sortByOrder %}
   {% include "components/projectlist.njk" %}
 </div>

--- a/index.njk
+++ b/index.njk
@@ -25,5 +25,5 @@ section: home
 
   <hr>
   <h1>projects</h1>
-  {% set projectlist = collections.project %}
+  {% set projectlist = collections.project | sortByOrder %}
   {% include "components/projectlist.njk" %}


### PR DESCRIPTION
Instead of targeting the 'project' collection specifically, we're using a filter that can be added to any collection, as long as `order` has a value in the markdown frontmatter